### PR TITLE
deleted `` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     install_requires = requirements,
     python_requires  = '>=' + cfg['min_python'],
     long_description = open('README.md').read(),
-    long_description_content_type = 'text/markdown',``
+    long_description_content_type = 'text/markdown',
     zip_safe = False,
     entry_points = { 'console_scripts': cfg.get('console_scripts','').split() },
     **setup_cfg)


### PR DESCRIPTION
Dear John, 

when trying to run `pip install -e .`  I got an Error message on several different devices. I had a look at the setup.py file and found two quotes, which were apparently the source of the error, as deleting those led to successful install. 

Forgive me my ignorance, if these quotes had a particular meaning, I have never written a setup.py myself...

Best wishes
pirwlan